### PR TITLE
Update naming_convention.rst

### DIFF
--- a/source/pages/naming_convention.rst
+++ b/source/pages/naming_convention.rst
@@ -10,7 +10,7 @@ Python Naming Conventions
 * Bad: data_structure, my_list, info_map, dictionary_for_the_purpose_of_storing_data_representing_word_definitions
 * Good: user_profile, menu_options, word_definitions
 * Don’t be a jackass and name things “O”, “l”, or “I”
-* When using CamelCase names, capitalize all letters of an abbreviation (e.g. HTTPServer)
+* When using CamelCase names, capitalize all letters of an acronym (e.g. HTTPServer)
 
 2. Packages
 ===========


### PR DESCRIPTION
HTTP (in the example) and generally most broadly used terms in IT (as 'IT' itself) are acronyms.